### PR TITLE
feat: udtg for checking if something is a blackboard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,6 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
             - ./node_modules
-      - run:
-          name: Set Up Environment
-          command: |
-            ci_scripts/ci_tool.sh --setup_npm
       - persist_to_workspace:
           root: ./
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ jobs:
       - run:
           name: Set Up Environment
           command: |
-            git submodule update --init --recursive
             ci_scripts/ci_tool.sh --setup_npm
       - persist_to_workspace:
           root: ./

--- a/lib/Blackboard.ts
+++ b/lib/Blackboard.ts
@@ -8,3 +8,14 @@ export interface Blackboard {
 	delete(ref: BlackboardRef<any>): boolean;
 	deleteAll(refs: BlackboardRef<any>[]): BlackboardRef<any>[];
 }
+
+function isFunction(maybeFunction: any): maybeFunction is Function {
+	return maybeFunction !== null && maybeFunction !== undefined && typeof maybeFunction === 'function';
+}
+
+export const BLACKBOARD_METHODS = Object.freeze(['create', 'get', 'tryGet', 'put', 'delete', 'deleteAll']);
+
+export function isBlackboard(maybeBlackboard: any): maybeBlackboard is Blackboard {
+	return (maybeBlackboard !== null && maybeBlackboard !== undefined)
+		&& !BLACKBOARD_METHODS.some((m) => !isFunction(maybeBlackboard[m]));
+}

--- a/lib/Blackboard.ts
+++ b/lib/Blackboard.ts
@@ -2,6 +2,7 @@ import {BlackboardRef} from './BlackboardRef';
 
 export interface Blackboard {
 	create<T>(ref: BlackboardRef<T>, value: T): void;
+	is<T>(ref: BlackboardRef<T>, value: T): boolean;
 	get<T>(ref: BlackboardRef<T>): T;
 	tryGet<T>(ref: BlackboardRef<T>): [true, T]|[false, undefined];
 	put<T>(ref: BlackboardRef<T>, value: T): void;
@@ -13,7 +14,7 @@ function isFunction(maybeFunction: any): maybeFunction is Function {
 	return maybeFunction !== null && maybeFunction !== undefined && typeof maybeFunction === 'function';
 }
 
-export const BLACKBOARD_METHODS = Object.freeze(['create', 'get', 'tryGet', 'put', 'delete', 'deleteAll']);
+export const BLACKBOARD_METHODS = Object.freeze(['create', 'get', 'tryGet', 'put', 'delete', 'deleteAll', 'is']);
 
 export function isBlackboard(maybeBlackboard: any): maybeBlackboard is Blackboard {
 	return (maybeBlackboard !== null && maybeBlackboard !== undefined)

--- a/lib/InMemoryMapBlackboard.ts
+++ b/lib/InMemoryMapBlackboard.ts
@@ -6,6 +6,10 @@ import {BlackboardError} from './BlackboardError';
 export class InMemoryMapBlackboard implements Blackboard {
 	private readonly state: Map<string, [BlackboardRef<any>, any]> = new Map();
 
+	public is<T>(ref: BlackboardRef<T>, value: T) {
+		return this.state.has(ref.uuid) && this.state.get(ref.uuid)![1] === value;
+	}
+
 	public get<T>(ref: BlackboardRef<T>) {
 		if (this.state.has(ref.uuid)) {
 			return InMemoryMapBlackboard.cloneObject(this.state.get(ref.uuid)![1]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "@sixriver/blackboard",
+	"name": "@6river/blackboard",
 	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/test/Blackboard.spec.ts
+++ b/test/Blackboard.spec.ts
@@ -1,0 +1,30 @@
+import {assert} from 'chai';
+import {isBlackboard, BLACKBOARD_METHODS} from '../lib/Blackboard';
+
+function getMockBlackboard() {
+	return BLACKBOARD_METHODS.reduce((obj, meth) => (obj[meth] = () => ({}), obj), {} as any);
+}
+
+describe('Blackboard', function() {
+	context('user-defined type-guard', function() {
+		it('succeeds when all properties are present and functions', function() {
+			assert.isTrue(isBlackboard(getMockBlackboard()));
+		});
+		context('per-property checks', function() {
+			for (const prop of BLACKBOARD_METHODS) {
+				context(prop, function() {
+					it('fails if prop is missing', function() {
+						const bb: any = getMockBlackboard();
+						delete bb[prop];
+						assert.isFalse(isBlackboard(bb));
+					});
+					it('fails if prop is wrong', function() {
+						const bb: any = getMockBlackboard();
+						bb[prop] = 'not a function';
+						assert.isFalse(isBlackboard(bb));
+					});
+				});
+			}
+		});
+	});
+});

--- a/test/InMemoryMapBlackboard.spec.ts
+++ b/test/InMemoryMapBlackboard.spec.ts
@@ -25,6 +25,63 @@ describe('InMemoryMapBlackboard', function() {
 		assert.isTrue(thrown);
 	});
 
+	context('is', function() {
+		let uut = new InMemoryMapBlackboard();
+		const bbRef = new BlackboardRef('test');
+		beforeEach(function() {
+			uut = new InMemoryMapBlackboard();
+		});
+		const refVals = [{}, [], new Map()];
+		const valVals = ['', 'test', 3, 0, -1, true, false];
+		const magicVals = [() => ({}), new Error('test')];
+		context('same as stored', function() {
+			const testTrue = (value: any) => () => {
+				uut.create(bbRef, value);
+				assert.isTrue(uut.is(bbRef, value));
+			};
+			context('reference types', function() {
+				for (const value of refVals) {
+					it(`works with ${value}`, testTrue(value));
+				}
+			});
+			context('value types', function() {
+				for (const value of valVals) {
+					it(`works with ${value}`, testTrue(value));
+				}
+			});
+			context('magic types', function() {
+				for (const value of magicVals) {
+					it(`works with ${value}`, testTrue(value));
+				}
+			});
+		});
+		context('get-clone', function() {
+			const testFalse = (value: any) => () => {
+				uut.create(bbRef, value);
+				assert.isFalse(uut.is(bbRef, uut.get(bbRef)));
+			};
+			const testTrue = (value: any) => () => {
+				uut.create(bbRef, value);
+				assert.isTrue(uut.is(bbRef, uut.get(bbRef)));
+			};
+			context('reference types', function() {
+				for (const value of refVals) {
+					it(`works with ${value}`, testFalse(value));
+				}
+			});
+			context('value types', function() {
+				for (const value of valVals) {
+					it(`works with ${value}`, testTrue(value));
+				}
+			});
+			context('magic types', function() {
+				for (const value of magicVals) {
+					it(`works with ${value}`, testTrue(value));
+				}
+			});
+		});
+	});
+
 	it('get', function() {
 		const uut = new InMemoryMapBlackboard();
 		const bbRef = new BlackboardRef('someName');


### PR DESCRIPTION
`isBlackboard` is a useful method for blueshell, which wants to know if its private state is properly initialized, to be able to check that not only is there a thing, but that thing is roughly blackboard-y. Keeping code 100% covered but also dry while dealing with non-runtime types leads to the kinda annoying array of method names.

`is`, as a method on Blackboard, allows checking for reference equality without making that reference available for possible accidental modification. This will be useful for tracking "is the last seen event the one I have" in blueshell. An alternative (optionally allow blackboard items to be flagged as "by reference") is possible, since we already do it (by necessity) for functions and errors, but this seems to open a smaller can of worms.